### PR TITLE
Leverage XDG_CONFIG_HOME

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1,7 +1,7 @@
 Configuration
 =============
 
-Configuration is stored in `~/.tunl/config.json`, which is created if it does not exist already.
+Configuration is stored in `~/.config/tunl/config.json`, which is created if it does not exist already.
 
 The format is basically `{tunnel_name : {..tunnel_info..}, .. }` (see the full example below).
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -13,7 +13,7 @@ USAGE
 | `tunl start TUNNEL_NAME` | start named tunnel |
 | `tunl stop TUNNEL_NAME` | stop named tunnel |
 
-To add a new tunnel with the given name and data to ~/.tunl configuration try something like this:
+To add a new tunnel with the given name and data to ~/.config/tunl configuration try something like this:
 
 ```shell
 tunl add TUNNEL_NAME --data "{remote_host:'remote_host', remote_port:123, local_port:123,}"`

--- a/tunl/data.py
+++ b/tunl/data.py
@@ -4,7 +4,8 @@ import os
 from .python import opj
 
 HOME = os.environ['HOME']
+XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME', opj(HOME, '.config'))
 SYSTEM_USER = os.environ['USER']
-TUNL_DIR = opj(HOME, '.tunl')
+TUNL_DIR = opj(XDG_CONFIG_HOME, 'tunl')
 TUNL_CONFIG = opj(TUNL_DIR, 'config.json')
 VERBOSE = False

--- a/tunl/data/__init__.py
+++ b/tunl/data/__init__.py
@@ -4,7 +4,8 @@ import os
 from tunl.python import opj
 
 HOME = os.environ['HOME']
+XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME', opj(HOME, '.config'))
 SYSTEM_USER = os.environ['USER']
-TUNL_DIR = opj(HOME, '.tunl')
+TUNL_DIR = opj(XDG_CONFIG_HOME, 'tunl')
 TUNL_CONFIG = opj(TUNL_DIR, 'config.json')
 VERBOSE = False


### PR DESCRIPTION
This moves the `~/.tunl` config directory to `~/.config/tunl`.
Note that if the user has a custom `XDG_CONFIG_HOME` set it'll it instead.

Ref: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html