### PR TITLE
Allow calling start|stop|status for multiple tunnels

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -9,9 +9,11 @@ USAGE
 | `tunl --help`    | show CLI help |
 | `tunl list` | list all known tunnel information |
 | `tunl status` | show status info for all tunnels |
-| `tunl status TUNNEL_NAME` | show status info for named tunnel |
-| `tunl start TUNNEL_NAME` | start named tunnel |
-| `tunl stop TUNNEL_NAME` | stop named tunnel |
+| `tunl start` | start all tunnels |
+| `tunl stop` | stop all tunnels |
+| `tunl status TUNNEL_NAME ...` | show status info for named tunnel(s) |
+| `tunl start TUNNEL_NAME ...` | start named tunnel(s) |
+| `tunl stop TUNNEL_NAME ...` | stop named tunnel(s) |
 
 To add a new tunnel with the given name and data to ~/.tunl configuration try something like this:
 

--- a/tunl/parsing.py
+++ b/tunl/parsing.py
@@ -35,8 +35,8 @@ def get_parser():
         'status', help='show tunnel status information')
     status_parser.set_defaults(subcommand='status')
     status_parser.add_argument(
-        'tunnel_name', nargs='?', default='',
-        help=("status for the named tunnel"))
+        'tunnel_name', nargs='*', default='',
+        help=("status for the named tunnel(s)"))
 
     edit_parser = subparsers.add_parser(
         'edit', help='edit tunl config')
@@ -46,15 +46,15 @@ def get_parser():
         'start', help='start the named tunnel')
     start_parser.set_defaults(subcommand='start')
     start_parser.add_argument(
-        'tunnel_name', default=os.getcwd(),
-        help=("start the named tunnel"))
+        'tunnel_name', nargs='*', default='',
+        help=("start the named tunnel(s)"))
 
     stop_parser = subparsers.add_parser(
         'stop', help='stop the named tunnel')
     stop_parser.set_defaults(subcommand='stop')
     stop_parser.add_argument(
-        'tunnel_name', default=os.getcwd(),
-        help=("stop the named tunnel"))
+        'tunnel_name', nargs='*', default='',
+        help=("stop the named tunnel(s)"))
     add_parser = subparsers.add_parser(
         'add', help='add new tunnel to configuration')
     add_parser.set_defaults(subcommand='add')


### PR DESCRIPTION
This commit allows the following:
```bash
tunl start TUNNEL1 TUNNEL2 TUNNEL3
tunl status TUNNEL1 TUNNEL2 TUNNEL3
tunl stop TUNNEL1 TUNNEL2 TUNNEL3
```
`tunl start|stop|status` without any tunnel name implies all tunnels, same as for `tunl start|stop|status all`
